### PR TITLE
MFA Flow

### DIFF
--- a/kibana/provider.go
+++ b/kibana/provider.go
@@ -2,11 +2,12 @@ package kibana
 
 import (
 	"fmt"
+	"log"
+	"os"
+
 	"github.com/ewilde/go-kibana"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
-	"log"
-	"os"
 )
 
 func Provider() terraform.ResourceProvider {
@@ -123,7 +124,10 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	client.Config.Debug = GetEnvVarOrDefaultBool("KIBANA_DEBUG", false)
 
 	if accountId, ok := d.GetOk("logzio_account_id"); ok && len(accountId.(string)) > 0 {
-		client.ChangeAccount(accountId.(string))
+		err := client.ChangeAccount(accountId.(string))
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return client, nil

--- a/vendor/github.com/ewilde/go-kibana/Makefile
+++ b/vendor/github.com/ewilde/go-kibana/Makefile
@@ -4,6 +4,7 @@ TEST?=$$(go list ./... |grep -v 'vendor')
 GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
 $(eval REMAINDER := $$$(ELK_VERSION))
 MAIN_VERSION := $(shell echo $(ELK_VERSION) | head -c 3)
+GO111MODULE := off
 
 default: build test
 

--- a/vendor/github.com/ewilde/go-kibana/README.md
+++ b/vendor/github.com/ewilde/go-kibana/README.md
@@ -141,6 +141,7 @@ env ELK_VERSION=6.2.1 KIBANA_TYPE=KibanaTypeVanilla make
 | KIBANA_URI| Your logz.io base uri i.e. https://app-eu.logz.io |
 | ELASTIC_SEARCH_PATH| Always /kibana/elasticsearch/logzioCustomerKibanaIndex for logz.io|
 | LOGZ_CLIENT_ID| Obtained for the POST data call to https://logzio.auth0.com/oauth/ro. Use chrome developer tools when you login to logz.io to obtain this. |
+|LOGZ_MFA_SECRET| _Optional_ One time password secret, if account requires MFA. |
 | KIBANA_USERNAME| Your logz.io username|
 | KIBANA_PASSWORD| Your logz.io password|
 | LOGZ_IO_ACCOUNT_ID_1| *Optional* Your primary logz.io account id, you can obtain this from the result or GET https://app-eu.logz.io/session. If not given will not run some tests to do with switching between multiple logz.io accounts|

--- a/vendor/github.com/ewilde/go-kibana/dashboard.go
+++ b/vendor/github.com/ewilde/go-kibana/dashboard.go
@@ -3,7 +3,8 @@ package kibana
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/satori/go.uuid"
+
+	uuid "github.com/satori/go.uuid"
 )
 
 type DashboardClient interface {
@@ -155,6 +156,9 @@ func (api *dashboardClient600) GetById(id string) (*Dashboard, error) {
 	}
 
 	if response.StatusCode >= 300 {
+		if api.config.KibanaType == KibanaTypeLogzio && response.StatusCode >= 400 { // bug in their api reports missing dashboard as bad request / server error
+			response.StatusCode = 404
+		}
 		return nil, NewError(response, body, "Could not fetch dashboard")
 	}
 

--- a/vendor/github.com/ewilde/go-kibana/kibana_client.go
+++ b/vendor/github.com/ewilde/go-kibana/kibana_client.go
@@ -2,11 +2,13 @@ package kibana
 
 import (
 	"fmt"
-	"github.com/google/go-querystring/query"
+	"log"
 	"net/url"
 	"os"
 	"reflect"
 	"strings"
+
+	"github.com/google/go-querystring/query"
 )
 
 const EnvElasticSearchPath = "ELASTIC_SEARCH_PATH"
@@ -22,6 +24,7 @@ const EnvLogzMfaSecret = "LOGZ_MFA_SECRET"
 const DefaultKibanaUri = "http://localhost:5601"
 const DefaultElasticSearchPath = "/es_admin/.kibana"
 const DefaultKibanaVersion6 = "6.0.0"
+const DefaultLogzioVersion = "6.3.2"
 const DefaultKibanaVersion553 = "5.5.3"
 const DefaultKibanaVersion = DefaultKibanaVersion6
 const DefaultKibanaIndexId = "logstash-*"
@@ -57,6 +60,7 @@ type Config struct {
 	KibanaBaseUri     string
 	KibanaVersion     string
 	KibanaType        KibanaType
+	Insecure          bool
 }
 
 type KibanaClient struct {
@@ -166,6 +170,7 @@ func NewDefaultConfig() *Config {
 		KibanaBaseUri:     DefaultKibanaUri,
 		KibanaVersion:     DefaultKibanaVersion,
 		KibanaType:        KibanaTypeVanilla,
+		Insecure:          false,
 	}
 
 	if value := os.Getenv(EnvElasticSearchPath); value != "" {
@@ -236,6 +241,11 @@ func (kibanaClient *KibanaClient) IndexPattern() IndexPatternClient {
 
 func (kibanaClient *KibanaClient) SavedObjects() SavedObjectsClient {
 	return getSavedObjectsClientFromVersion(kibanaClient.Config.KibanaVersion, kibanaClient)
+}
+
+func (kibanaClient *KibanaClient) SetLogger(logger *log.Logger) *KibanaClient {
+	kibanaClient.client.SetLogger(logger)
+	return kibanaClient
 }
 
 func (config *Config) BuildFullPath(format string, a ...interface{}) string {

--- a/vendor/github.com/ewilde/go-kibana/logzio_authentication_handler.go
+++ b/vendor/github.com/ewilde/go-kibana/logzio_authentication_handler.go
@@ -4,14 +4,19 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/parnurzeal/gorequest"
-	"github.com/xlzd/gotp"
 	"log"
 	"regexp"
 	"time"
+
+	"github.com/parnurzeal/gorequest"
+	"github.com/xlzd/gotp"
 )
 
 var mfaCodeExpiredError = errors.New("the mfa code sent is expired")
+
+func NewLogzAuthenticationHandler(agent *gorequest.SuperAgent) *LogzAuthenticationHandler {
+	return &LogzAuthenticationHandler{}
+}
 
 func (auth *LogzAuthenticationHandler) Initialize(agent *gorequest.SuperAgent) error {
 	if auth.sessionToken != "" {
@@ -19,6 +24,77 @@ func (auth *LogzAuthenticationHandler) Initialize(agent *gorequest.SuperAgent) e
 		return nil
 	}
 
+	if auth.MfaSecret != "" {
+		return auth.initializeWithMFA(agent)
+	} else {
+		return auth.initializeWithAuth0(agent)
+	}
+}
+
+func (auth *LogzAuthenticationHandler) initializeWithAuth0(agent *gorequest.SuperAgent) error {
+	csrfToken, err := auth.getCSRFToken()
+
+	if err != nil {
+		return err
+	}
+
+	request := gorequest.New()
+	response, body, errs := request.Post(fmt.Sprintf("%s/oauth/ro", auth.Auth0Uri)).
+		Set("kbn-version", DefaultKibanaVersion553).
+		Set("Content-Type", "application/x-www-form-urlencoded").
+		Type("form").
+		Send(fmt.Sprintf(`{
+  "scope": "openid email connection",
+  "response_type": "code",
+  "connection": "Username-Password-Authentication",
+  "username": "%s",
+  "password": "%s",
+  "grant_type": "password",
+  "client_id": "%s"
+}`, auth.UserName, auth.Password, auth.ClientId)).
+		End()
+
+	if errs != nil {
+		return errs[0]
+	}
+
+	if response.StatusCode >= 300 {
+		return errors.New(fmt.Sprintf("Status: %d, %s", response.StatusCode, body))
+	}
+
+	authResponse := &Auth0Response{}
+	if err := json.Unmarshal([]byte(body), authResponse); err != nil {
+		return err
+	}
+
+	response, body, errs = request.Post(fmt.Sprintf("%s/login/jwt", auth.LogzUri)).
+		Set("x-logz-csrf-token", csrfToken).
+		Set("cookie", fmt.Sprintf("Logzio-Csrf=%s", csrfToken)).
+		Send(fmt.Sprintf(`{
+  "jwt": "%s"
+}`, authResponse.IdTokens)).
+		End()
+
+	if errs != nil {
+		return errs[0]
+	}
+
+	if response.StatusCode >= 400 {
+		return fmt.Errorf("error logging in (%d). %s", response.StatusCode, string(body))
+	}
+
+	jwtResponse := map[string]interface{}{}
+	if err := json.Unmarshal([]byte(body), &jwtResponse); err != nil {
+		return err
+	}
+
+	auth.sessionToken = jwtResponse["sessionToken"].(string)
+	auth.setLogzHeaders(agent)
+	return nil
+}
+
+func (auth *LogzAuthenticationHandler) initializeWithMFA(agent *gorequest.SuperAgent) error {
+	request := gorequest.New()
 	csrfToken, err := auth.getCSRFToken()
 
 	if err != nil {
@@ -28,20 +104,29 @@ func (auth *LogzAuthenticationHandler) Initialize(agent *gorequest.SuperAgent) e
 	mfaCode, secondsLeftForMfaToExpire := auth.getMfaCodeWithExpiry()
 	sessionToken, err := auth.getLogzioSessionToken(mfaCode)
 
+	// Attempt regeneration if possible
 	if err == mfaCodeExpiredError && secondsLeftForMfaToExpire < 5 {
 		log.Print("The mfa code was too close to expiry, so we re-generate and try again")
 		mfaCode, secondsLeftForMfaToExpire = auth.getMfaCodeWithExpiry()
 		sessionToken, err = auth.getLogzioSessionToken(mfaCode)
 	}
 
-	request := gorequest.New()
-	_, body, errs := request.Post(fmt.Sprintf("%s/login/jwt", auth.LogzUri)).
+	// If we're still failing, we cannot proceed
+	if err != nil {
+		return fmt.Errorf("Error getting MFA code: %s", err)
+	}
+
+	response, body, errs := request.Post(fmt.Sprintf("%s/login/jwt", auth.LogzUri)).
 		Set("x-logz-csrf-token", csrfToken).
 		Set("cookie", fmt.Sprintf("Logzio-Csrf=%s", csrfToken)).
 		Send(fmt.Sprintf(`{
 	  "jwt": "%s"
 	}`, sessionToken)).
 		End()
+
+	if response.StatusCode >= 400 {
+		return fmt.Errorf("error logging in (%d). %s", response.StatusCode, string(body))
+	}
 
 	if errs != nil {
 		return errs[0]
@@ -56,6 +141,7 @@ func (auth *LogzAuthenticationHandler) Initialize(agent *gorequest.SuperAgent) e
 	auth.setLogzHeaders(agent)
 	return nil
 }
+
 func (auth *LogzAuthenticationHandler) ChangeAccount(accountId string, agent *HttpAgent) error {
 	response, body, errs := agent.Get(fmt.Sprintf("%s/user/session/replace/%s", auth.LogzUri, accountId)).End()
 	if errs != nil {
@@ -90,6 +176,7 @@ func (auth *LogzAuthenticationHandler) getCSRFToken() (string, error) {
 		return "", errors.New("could not retrieve CSRF token from logz.io cookie")
 	}
 	csrfToken := cookieRegExMatches[1]
+	auth.csrfToken = csrfToken
 	return csrfToken, nil
 }
 
@@ -140,7 +227,8 @@ func (auth *LogzAuthenticationHandler) getMfaCodeWithExpiry() (string, int64) {
 
 func (auth *LogzAuthenticationHandler) setLogzHeaders(agent *gorequest.SuperAgent) *gorequest.SuperAgent {
 	return agent.
-		Set("Content-Type", "application/json").
-		Set("x-auth-token", auth.sessionToken)
-
+		Set("x-logz-csrf-token", auth.csrfToken).
+		Set("cookie", fmt.Sprintf("Logzio-Csrf=%s", auth.csrfToken)).
+		Set("x-auth-token", auth.sessionToken).
+		Set("Content-Type", "application/json")
 }

--- a/vendor/github.com/ewilde/go-kibana/search_600.go
+++ b/vendor/github.com/ewilde/go-kibana/search_600.go
@@ -86,6 +86,9 @@ func (api *searchClient600) GetById(id string) (*Search, error) {
 	}
 
 	if response.StatusCode >= 300 {
+		if api.config.KibanaType == KibanaTypeLogzio && response.StatusCode >= 400 { // bug in their api reports missing search as bad request or server error
+			response.StatusCode = 404
+		}
 		return nil, NewError(response, body, "Could not fetch search")
 	}
 

--- a/vendor/github.com/ewilde/go-kibana/visualization.go
+++ b/vendor/github.com/ewilde/go-kibana/visualization.go
@@ -3,7 +3,8 @@ package kibana
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/satori/go.uuid"
+
+	uuid "github.com/satori/go.uuid"
 )
 
 type VisualizationClient interface {
@@ -132,6 +133,9 @@ func (api *visualizationClient600) GetById(id string) (*Visualization, error) {
 	}
 
 	if response.StatusCode >= 300 {
+		if api.config.KibanaType == KibanaTypeLogzio && response.StatusCode >= 400 { // bug in their api reports missing visualization as bad request / server error
+			response.StatusCode = 404
+		}
 		return nil, NewError(response, body, "Could not fetch visualization")
 	}
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -399,10 +399,10 @@
 			"revisionTime": "2017-01-27T09:51:30Z"
 		},
 		{
-			"checksumSHA1": "uwwzbJmEo4MYRus+WZ37ZaBglmQ=",
+			"checksumSHA1": "X7XzOQDfBnn6RTE8/Jvjvvl/pCg=",
 			"path": "github.com/ewilde/go-kibana",
-			"revision": "2bfd0fdbdd9098a079a10d2caab6bbc134022a7a",
-			"revisionTime": "2019-04-03T15:10:54Z"
+			"revision": "ea0acca996cc3bcae47274630000d28f3b1cd5a3",
+			"revisionTime": "2019-08-13T14:10:25Z"
 		},
 		{
 			"checksumSHA1": "2iG1OyYDGax71qsun0zBSdcFt4E=",


### PR DESCRIPTION
* Catch ChangeAccount errors. Previously the provider would charge ahead with failed auth and hammer the API.
* Update go-kibana to pull in the latest changes (including MFA support).