### PR TITLE
Upgrade go kibana

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ewilde/terraform-provider-kibana
 go 1.13
 
 require (
-	github.com/ewilde/go-kibana v0.0.0-20191210182714-d7799b1ab551
+	github.com/ewilde/go-kibana v0.0.0-20201120090515-b1d2ef27f611
 	github.com/hashicorp/hcl v0.0.0-20171017181929-23c074d0eceb // indirect
 	github.com/hashicorp/terraform v0.12.13 // indirect
 	github.com/hashicorp/terraform-plugin-sdk v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -98,6 +98,8 @@ github.com/ewilde/go-kibana v0.0.0-20191107065138-7c4b5422c952 h1:UZpJHnOfs9EVWo
 github.com/ewilde/go-kibana v0.0.0-20191107065138-7c4b5422c952/go.mod h1:O5iM94wkeZicbmZPcp6s2JXKyKuPD6OGcHgb39B3TEk=
 github.com/ewilde/go-kibana v0.0.0-20191210182714-d7799b1ab551 h1:KXiWhU8KM2z4lbv1WH1vRRuV1EH39pNkXimG1rzVXUs=
 github.com/ewilde/go-kibana v0.0.0-20191210182714-d7799b1ab551/go.mod h1:O5iM94wkeZicbmZPcp6s2JXKyKuPD6OGcHgb39B3TEk=
+github.com/ewilde/go-kibana v0.0.0-20201120090515-b1d2ef27f611 h1:TqSPsegwPur1CjPbc8ZJDE6EgFROoFtyeHDRpMKa4pU=
+github.com/ewilde/go-kibana v0.0.0-20201120090515-b1d2ef27f611/go.mod h1:O5iM94wkeZicbmZPcp6s2JXKyKuPD6OGcHgb39B3TEk=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=


### PR DESCRIPTION
This PR upgrades the `go-kibana` version of this provider to the latest, that fixes some issues related with parsing CSRF tokens from logz.io.