### PR TITLE
Fix Goreleaser yaml

### DIFF
--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -6,5 +6,6 @@ builds:
       - windows
     goarch:
       - amd64
-archive:
-  format: zip
+archives:
+  - id: default
+    format: zip


### PR DESCRIPTION
Brings the `goreleaser.yml` spec into a format that can be parsed by the current version of goreleaser:

```
$ goreleaser -v
goreleaser version 0.152.0

$  goreleaser check
   • loading config file       file=goreleaser.yml
   • checking config:
      • snapshotting
      • github/gitlab/gitea releases
      • project name
      • building binaries
      • creating source archive
      • archives
      • linux packages
      • snapcraft packages
      • calculating checksums
      • signing artifacts
      • docker images
      • artifactory
      • blobs
      • homebrew tap formula
      • scoop manifests
      • milestones
   • config is valid
```